### PR TITLE
201708 list control direct sel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@ You need to have the (local) IP-address of your receiver to add the device to Ho
 
 Use at your own risk, I accept no responsibility for any damages caused by using this script.
 
-#Donations
+# Donations
 Are always appreciated :)
 [![](https://www.paypalobjects.com/en_US/NL/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=CWQL5MRKGHH5U)
 
-#Changelog
-Version 0.3.0
+# Changelog
 
-Adding support of MusicCast devices and partial re-write of the app following from this.
+##### Version 0.3.1
+- Adding Flow Action: Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB). 
+
+##### Version 0.3.0
+- Adding support of MusicCast devices and partial re-write of the app following from this.
 Huge thanks to Frank for the integration!
 
-Version 0.2.5
+##### Version 0.2.5
+- Fixed not auto-reconnecting on Homey restart
 
-Fixed not auto-reconnecting on Homey restart
+##### Version 0.2.1 - Version 0.2.4
+- Bugfixes
 
-Version 0.2.1 - Version 0.2.4
-
-Bugfixes
-
-Version 0.2.0
-
-Big rewrite of the app.
-YOU MUST REMOVE THE RECEIVER FROM THE HOMEY DEVICES AND RE-ADD IT!
+##### Version 0.2.0
+*Big rewrite of the app.
+YOU MUST REMOVE THE RECEIVER FROM THE HOMEY DEVICES AND RE-ADD IT!*
 
 Added functionality:
 * Mobile cards to turn on/off, change volume, change source
@@ -38,21 +38,18 @@ Added functionality:
 * Support for multiple zones of the receiver (Main_Zone, Zone_2, etc)
 * More source possibilities (f.e. HDMI6-8)
 
-Version 0.1.1
+##### Version 0.1.1
+- Update capabilities crash v0.9.x
 
-Update capabilities crash v0.9.x
-
-Version 0.1.0
+##### Version 0.1.0
 
 Currently working:
-* Turning receiver on/off
-* Mute/unmute receiver
-* Increase/decrease volume
-* Set volume to a certain value
-* Change source of receiver
-* Change music equaliser settings of receiver
-
-Turning receiver on this way takes 10-20 seconds, take care of this when using in a flow with something else (i.e., delay a command to change the receiver input if you want 1 flow to both turn the receiver on and change the input).
-
-Fixed settings being destroyed upon restart
-Added nice green check-mark in flows
+- Turning receiver on/off
+- Mute/unmute receiver
+- Increase/decrease volume
+- Set volume to a certain value
+- Change source of receiver
+- Change music equaliser settings of receiver
+    - Turning receiver on this way takes 10-20 seconds, take care of this when using in a flow with something else (i.e., delay a command to change the receiver input if you want 1 flow to both turn the receiver on and change the input).
+- Fixed settings being destroyed upon restart
+- Added nice green check-mark in flows

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Are always appreciated :)
 # Changelog
 
 ##### Version 0.3.1
-- Adding Flow Action: Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB). 
+- Adding Flow Action: Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB).
+- Fixed incorrect behavior on the Flows page (actions where listed below Apps instead of Devices).
 
 ##### Version 0.3.0
 - Adding support of MusicCast devices and partial re-write of the app following from this.

--- a/app.json
+++ b/app.json
@@ -376,261 +376,465 @@
     ],
     "flow": {
 	    "actions": [
-        {
-            "id": "powerOn",
-            "title": {
-                "en": "Turn power on",
-                "nl": "Aanzetten"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
+            {
+                "id": "powerOn",
+                "title": {
+                    "en": "Turn power on",
+                    "nl": "Aanzetten"
                 },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              }
-            ]
-        },
-        {
-            "id": "powerOff",
-            "title": {
-                "en": "Power off/standby",
-                "nl": "Uitschakelen/standby"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              }
-            ]
-        },{
-            "id": "mute",
-            "title": {
-                "en": "Mute",
-                "nl": "Mute"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              }
-            ]
-        },{
-            "id": "unMute",
-            "title": {
-                "en": "Mute Off",
-                "nl": "Mute Uit"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              }
-            ]
-        },
-        {
-            "id": "setVolume",
-            "title": {
-                "en": "Change volume",
-                "nl": "Verander volume"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-                "filter": "driver_uri=homey:app:martens.yamaha"
-              },
-              {
-                "name": "volume",
-                "type": "range",
-                "min": 0,
-                "max": 100,
-                "step": 1,
-                "label": "%"
-              }
-            ]
-        },
-        {
-            "id": "volumeUp",
-            "title": {
-                "en": "Raise volume",
-                "nl": "Zet geluid harder"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-                "filter": "driver_uri=homey:app:martens.yamaha"
-              },
-              {
-                "name": "volume",
-                "type": "range",
-                "min": 0,
-                "max": 100,
-                "step": 1,
-                "label": "dB"
-              }
-            ]
-        },
-        {
-            "id": "volumeDown",
-            "title": {
-                "en": "Lower volume",
-                "nl": "Zet geluid zachter"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-                "filter": "driver_uri=homey:app:martens.yamaha"
-              },
-              {
-                "name": "volume",
-                "type": "range",
-                "min": 0,
-                "max": 100,
-                "step": 1,
-                "label": "dB"
-              }
-            ]
-        },
-		{
-            "id": "changeSource",
-            "title": {
-                "en": "Change source",
-                "nl": "Bron selecteren"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              },
-			  {
-				"name": "input",
-				"type": "autocomplete",
-				"placeholder": {
-				  "en": "input",
-				  "nl": "input"
-				}
-			  }
-            ]
-        },
-		{
-            "id": "changeSurround",
-            "title": {
-                "en": "Change surround options",
-                "nl": "Surround opties aanpassen"
-            },
-            "args": [
-              {
-                "name": "device",
-                "type": "device",
-                "placeholder": {
-                  "en": "Select receiver",
-                  "nl": "Selecteer receiver"
-                },
-	            "filter": "driver_uri=homey:app:martens.yamaha"
-              },
-			  {
-				"name": "input",
-				"type": "autocomplete",
-				"placeholder": {
-				  "en": "input",
-				  "nl": "input"
-				}
-			  }
-            ]
-        },
-        {
-            "id": "ListControl_DirectSel",
-            "title": {
-                "en": "Select line x",
-                "nl": "Selecteer regel x"
-            },
-            "hint": {
-                "en": "Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB).",
-                "nl": "Selecteer een specifieke regel binnen een menu (alleen voor menu gebaseerde inputs zoals Net Radio, Server, USB)."
-            },
-            "args": [
-                {
-                    "name": "device",
-                    "type": "device",
-                    "placeholder": {
-                        "en": "Select receiver",
-                        "nl": "Selecteer receiver"
-                    },
-                    "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
-                },
-                {
-                    "name": "input",
-                    "type": "dropdown",
-                    "values": [
-                        {
-                            "id": "NET_RADIO",
-                            "label": {
-                                "en": "NET RADIO"
-                            }
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
                         },
-                        {
-                            "id": "USB",
-                            "label": {
-                                "en": "USB"
-                            }
-                        },
-                        {
-                            "id": "SERVER",
-                            "label": {
-                                "en": "SERVER"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "line",
-                    "type": "number",
-                    "min": 1,
-                    "placeholder": {
-                        "en": "Line number",
-                        "nl": "Regel nummer"
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
                     }
-                }
-            ]
-        }
-      ]
+                ]
+            },
+            {
+                "id": "powerOff",
+                "title": {
+                    "en": "Power off/standby",
+                    "nl": "Uitschakelen/standby"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    }
+                ]
+            },
+            {
+                "id": "mute",
+                "title": {
+                    "en": "Mute",
+                    "nl": "Mute"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    }
+                ]
+            },
+            {
+                "id": "unMute",
+                "title": {
+                    "en": "Mute Off",
+                    "nl": "Mute Uit"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    }
+                ]
+            },
+            {
+                "id": "setVolume",
+                "title": {
+                    "en": "Change volume",
+                    "nl": "Verander volume"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "%"
+                    }
+                ]
+            },
+            {
+                "id": "volumeUp",
+                "title": {
+                    "en": "Raise volume",
+                    "nl": "Zet geluid harder"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "dB"
+                    }
+                ]
+            },
+            {
+                "id": "volumeDown",
+                "title": {
+                    "en": "Lower volume",
+                    "nl": "Zet geluid zachter"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "dB"
+                    }
+                ]
+            },
+            {
+                "id": "changeSource",
+                "title": {
+                    "en": "Change source",
+                    "nl": "Bron selecteren"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    },
+                    {
+                        "name": "input",
+                        "type": "autocomplete",
+                        "placeholder": {
+                            "en": "input",
+                            "nl": "input"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "changeSurround",
+                "title": {
+                    "en": "Change surround options",
+                    "nl": "Surround opties aanpassen"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=musiccast"
+                    },
+                    {
+                        "name": "input",
+                        "type": "autocomplete",
+                        "placeholder": {
+                            "en": "input",
+                            "nl": "input"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "powerOn",
+                "title": {
+                    "en": "Turn power on",
+                    "nl": "Aanzetten"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    }
+                ]
+            },
+            {
+                "id": "powerOff",
+                "title": {
+                    "en": "Power off/standby",
+                    "nl": "Uitschakelen/standby"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    }
+                ]
+            },
+            {
+                "id": "mute",
+                "title": {
+                    "en": "Mute",
+                    "nl": "Mute"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    }
+                ]
+            },
+            {
+                "id": "unMute",
+                "title": {
+                    "en": "Mute Off",
+                    "nl": "Mute Uit"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    }
+                ]
+            },
+            {
+                "id": "setVolume",
+                "title": {
+                    "en": "Change volume",
+                    "nl": "Verander volume"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "%"
+                    }
+                ]
+            },
+            {
+                "id": "volumeUp",
+                "title": {
+                    "en": "Raise volume",
+                    "nl": "Zet geluid harder"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "dB"
+                    }
+                ]
+            },
+            {
+                "id": "volumeDown",
+                "title": {
+                    "en": "Lower volume",
+                    "nl": "Zet geluid zachter"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "volume",
+                        "type": "range",
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "label": "dB"
+                    }
+                ]
+            },
+            {
+                "id": "changeSource",
+                "title": {
+                    "en": "Change source",
+                    "nl": "Bron selecteren"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "input",
+                        "type": "autocomplete",
+                        "placeholder": {
+                            "en": "input",
+                            "nl": "input"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "changeSurround",
+                "title": {
+                    "en": "Change surround options",
+                    "nl": "Surround opties aanpassen"
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "input",
+                        "type": "autocomplete",
+                        "placeholder": {
+                            "en": "input",
+                            "nl": "input"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "ListControl_DirectSel",
+                "title": {
+                    "en": "Select line x",
+                    "nl": "Selecteer regel x"
+                },
+                "hint": {
+                    "en": "Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB).",
+                    "nl": "Selecteer een specifieke regel binnen een menu (alleen voor menu gebaseerde inputs zoals Net Radio, Server, USB)."
+                },
+                "args": [
+                    {
+                        "name": "device",
+                        "type": "device",
+                        "placeholder": {
+                            "en": "Select receiver",
+                            "nl": "Selecteer receiver"
+                        },
+                        "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                    },
+                    {
+                        "name": "input",
+                        "type": "dropdown",
+                        "values": [
+                            {
+                                "id": "NET_RADIO",
+                                "label": {
+                                    "en": "NET RADIO"
+                                }
+                            },
+                            {
+                                "id": "USB",
+                                "label": {
+                                    "en": "USB"
+                                }
+                            },
+                            {
+                                "id": "SERVER",
+                                "label": {
+                                    "en": "SERVER"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "line",
+                        "type": "number",
+                        "min": 1,
+                        "placeholder": {
+                            "en": "Line number",
+                            "nl": "Regel nummer"
+                        }
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
         "en": "Yamaha receiver",
         "nl": "Yamaha receiver"
     },
-    "version": "0.3.0",
+    "version": "0.3.1",
     "compatibility": "0.x || 1.x",
     "author": {
         "name": "Koen Martens",
@@ -574,6 +574,61 @@
 				  "nl": "input"
 				}
 			  }
+            ]
+        },
+        {
+            "id": "ListControl_DirectSel",
+            "title": {
+                "en": "Select line x",
+                "nl": "Selecteer regel x"
+            },
+            "hint": {
+                "en": "Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB).",
+                "nl": "Selecteer een specifieke regel binnen een menu (alleen voor menu gebaseerde inputs zoals Net Radio, Server, USB)."
+            },
+            "args": [
+                {
+                    "name": "device",
+                    "type": "device",
+                    "placeholder": {
+                        "en": "Select receiver",
+                        "nl": "Selecteer receiver"
+                    },
+                    "filter": "driver_uri=homey:app:martens.yamaha&driver_id=receiver"
+                },
+                {
+                    "name": "input",
+                    "type": "dropdown",
+                    "values": [
+                        {
+                            "id": "NET_RADIO",
+                            "label": {
+                                "en": "NET RADIO"
+                            }
+                        },
+                        {
+                            "id": "USB",
+                            "label": {
+                                "en": "USB"
+                            }
+                        },
+                        {
+                            "id": "SERVER",
+                            "label": {
+                                "en": "SERVER"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "line",
+                    "type": "number",
+                    "min": 1,
+                    "placeholder": {
+                        "en": "Line number",
+                        "nl": "Regel nummer"
+                    }
+                }
             ]
         }
       ]

--- a/drivers/receiver/driver.js
+++ b/drivers/receiver/driver.js
@@ -353,6 +353,12 @@ module.exports.volumeDown = function (callback, args){
 	callback(null, true);
 };
 
+// Driver specific flows.
+Homey.manager('flow').on('action.ListControl_DirectSel', function (callback, args) {
+	SendXMLToReceiver(args.device.ipaddress, '<YAMAHA_AV cmd="PUT"><' + args.input + '><List_Control><Direct_Sel>Line_' + args.line + '</Direct_Sel></List_Control></NET_RADIO></YAMAHA_AV>');
+	callback(null, true);
+});
+
 //Set and get XML information
 function SendXMLToReceiver (ipaddress,xml){
 	try{


### PR DESCRIPTION
I wanted to automatically start NET_RADIO each morning on my favorite music station, but there was no flow available to Select a menu item, so I created that.

Changes:
- Adding Flow Action: Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB). 
- Fixed incorrect behavior on the Flows page (actions where listed below Apps instead of Devices).

Also did some formatting on the readme.