### PR TITLE
Homey 2.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Are always appreciated :)
 
 # Changelog
 
-##### Version 0.3.1 (beta)
+##### Version 0.3.2
+- Homey 2.0 compatibility
+
+##### Version 0.3.1
 - Adding Flow Action: Select a specific line within a menu (only for menu based inputs like Net Radio, Server, USB).
 - Fixed incorrect behavior on the Flows page (actions where listed below Apps instead of Devices).
 - Note: Re-adding of the receiver is necessary! Sorry for this.

--- a/app.json
+++ b/app.json
@@ -4,8 +4,8 @@
         "en": "Yamaha receiver",
         "nl": "Yamaha receiver"
     },
-    "version": "0.3.1",
-    "compatibility": "0.x || 1.x",
+    "version": "0.3.2",
+    "compatibility": ">=1.5.0",
     "author": {
         "name": "Koen Martens",
         "email": "koen-martens@hotmail.com"


### PR DESCRIPTION
Fixed the "Er is een onbekende fout opgetreden [incompatible_app_version]" error and successfully tested on Homey 2.0